### PR TITLE
Fix product impact override

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Leverage Red Hat's Security Data API to find CVEs by various attributes (date, severity, scores, package, IAVA, etc). Retrieve customizable details about found CVEs or about specific CVE ids input on cmdline. Parse arbitrary stdin for CVE ids and generate a customized report, optionally sending it straight to pastebin. Searches are done via a single instantaneous http request and CVE retrieval is parallelized, utilizing multiple threads at once. Python requests is used for all remote communication, so proxy support is baked right in. BASH intelligent tab-completion is supported via optional Python argcomplete module.
 
-Forked from [https://github.com/RedHatOfficial/rhsecapi]https://github.com/RedHatOfficial/rhsecapi. Updated to work with Python 3
+Forked from [https://github.com/RedHatOfficial/rhsecapi](https://github.com/RedHatOfficial/rhsecapi). Updated to work with Python 3
 
 ## Jump to ...
 - [rhsecapi](#rhsecapi)

--- a/rhsda.py
+++ b/rhsda.py
@@ -499,6 +499,7 @@ class ApiClient:
                 # When there's only one, it doesn't show up in a list
                 affected_release = [affected_release]
             for release in affected_release:
+                print(str(release))
                 if self.cfg.product:
                     if self.regex_product.search(release['product_name']) or self.regex_product.search(release['cpe']):
                         foundProduct_affected_release = True
@@ -511,7 +512,10 @@ class ApiClient:
                 advisory = release['advisory']
                 if self.cfg.urls:
                     advisory = "https://access.redhat.com/errata/{0}".format(advisory)
-                out.append("   {0}:{1} via {2} ({3})".format(release['product_name'], pkg, advisory, release['release_date'].split("T")[0]))
+                impact = ""
+                if 'impact' in release: 
+                    impact = " {{{0}}}".format(release['impact'].upper())
+                out.append("   {0}:{1}{2} via {3} ({4})".format(release['product_name'], pkg, impact, advisory, release['release_date'].split("T")[0]))
             if self.cfg.product and not foundProduct_affected_release:
                 # If nothing found, remove the "FIXED_RELEASES" heading
                 out.pop()
@@ -536,7 +540,10 @@ class ApiClient:
                 pkg = ""
                 if 'package_name' in state:
                     pkg = " [{0}]".format(state['package_name'])
-                out.append("   {0}: {1}{2}".format(state['fix_state'], state['product_name'], pkg))
+                impact = ""
+                if 'impact' in state: 
+                    impact = " {{{0}}}".format(state['impact'].upper())
+                out.append("   {0}: {1}{2}{3}".format(state['fix_state'], state['product_name'], pkg, impact))
             if self.cfg.product and not foundProduct_package_state:
                 # If nothing found, remove the "FIX_STATES" heading
                 out.pop()


### PR DESCRIPTION
Per product impact overrides where added to the Security Data API. Also adding them to fix state, and fixed releases output.